### PR TITLE
Phase 1.6: add threading.Lock to Store for thread safety

### DIFF
--- a/TRACKING.md
+++ b/TRACKING.md
@@ -23,10 +23,10 @@ Codebase analysis: [`ai-working-log/REPORT.md`](ai-working-log/REPORT.md)
 |---|------|--------|
 | 1.1 | Fix `requirements.txt` (add mido, rtmidi, PyOpenGL; remove pygame 1.9.6) | ✅ Done |
 | 1.2 | Remove `pygame.midi`, replace with `python-rtmidi` throughout | ✅ Done |
-| 1.3 | Remove `pyautogui` keyboard simulation; wire MIDI events directly to game loop | ⬜ Todo |
-| 1.4 | Replace `Mp3Player` (Windows-only MCI) with `pygame.mixer` | ⬜ Todo |
-| 1.5 | Delete deprecated `GameStageScene.py` (2D scene); keep OpenGL renderer | ⬜ Todo |
-| 1.6 | Add thread safety (`threading.Lock` or `queue.Queue`) to shared `Store` | ⬜ Todo |
+| 1.3 | Remove `pyautogui` keyboard simulation; wire MIDI events directly to game loop | ✅ Done |
+| 1.4 | Replace `Mp3Player` (Windows-only MCI) with `pygame.mixer` | ✅ Done |
+| 1.5 | Delete deprecated `GameStageScene.py` (2D scene); keep OpenGL renderer | ✅ Done |
+| 1.6 | Add thread safety (`threading.Lock` or `queue.Queue`) to shared `Store` | ✅ Done |
 
 ## Phase 2 — Game Engine
 
@@ -59,6 +59,25 @@ Codebase analysis: [`ai-working-log/REPORT.md`](ai-working-log/REPORT.md)
 - Fixed `InputController.py` bug: missing `initial=False` parameter default
 - Wrote `ai-working-log/DESIGN.md`: full redesign specification for MidiMania
 - Decided to keep PyOpenGL renderer (perspective projection already works; pygame 2D cannot replicate vanishing-point effect without manual math)
+
+### Session 3 (this session)
+**Completed Phase 1.3–1.6**
+
+Phase 1.3 — Remove `pyautogui` keyboard simulation:
+- `KeyCodeConstants.py`: removed `import pyautogui`; dropped `pyautogui.KEY_NAMES` initializer; replaced with plain dict literal; `get_key_code()` now returns `None` for unknown keys via `dict.get()`
+- `KeyMapper.py`: dropped all pyautogui imports and `pyautogui.PAUSE = 0`; `map_midi()` now posts `pygame.KEYDOWN`/`pygame.KEYUP` events directly via `pygame.event.post()`; MIDI input reaches the game loop as native pygame events without OS-level keyboard simulation
+
+Phase 1.4 — Replace `Mp3Player` with `pygame.mixer`:
+- `Mp3Player/__init__.py`: full rewrite using `pygame.mixer.music`; cross-platform (Windows/macOS/Linux); public API preserved (`play/pause/unpause/stop/isplaying/ispaused/volume/milliseconds/seconds`)
+- `Mp3Player/windows.py`: deleted (Windows MCI implementation)
+- `Mp3Player/readme.txt`: deleted
+
+Phase 1.5 — Delete deprecated `GameStageScene.py`:
+- `ui/scenes/GameStageScene.py`: deleted (2D renderer, superseded by OpenGL renderer)
+- `ui/GameDisplay.py`: removed `GameStageScene` import; `render()` is a no-op stub pending Phase 3.3
+
+Phase 1.6 — Thread safety for `Store`:
+- `controllers/__init__.py`: added `threading.Lock`; `get()` and `put()` protected with `with self._lock`; also simplified `get()` using `dict.get()`
 
 ### Session 2 (this commit)
 **Completed Phase 1.2: remove `pygame.midi`, replace with `python-rtmidi`**

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -1,3 +1,6 @@
+import threading
+
+
 class Controller:
     def __init__(self):
         self.store = Store()
@@ -10,11 +13,12 @@ class Controller:
 class Store:
     def __init__(self):
         self.storage = {}
+        self._lock = threading.Lock()
 
     def get(self, key):
-        if key not in self.storage.keys():
-            return None
-        return self.storage[key]
+        with self._lock:
+            return self.storage.get(key)
 
     def put(self, key, value):
-        self.storage[key] = value
+        with self._lock:
+            self.storage[key] = value


### PR DESCRIPTION
## Summary

- `controllers/__init__.py`: added `threading.Lock`; `Store.get()` and `Store.put()` are now protected with `with self._lock` so reads and writes are atomic. Fixes a data race where `InputMidiQueue`, `InputUIEventQueue`, and `InputKeyboardEventQueue` all access the same `Store` instance concurrently without synchronisation.
- Also simplified `Store.get()`: replaced the explicit key-in-dict check with `dict.get(key)` which returns `None` by default.

Also includes the TRACKING.md update marking Phase 1.3–1.6 as complete.

## Test plan

- [ ] Run game with active MIDI input — no threading exceptions
- [ ] Run existing tests: `pytest tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)